### PR TITLE
AMRNAV-8018 Cycle gain and exposure per frame

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -1084,31 +1084,37 @@ bool PylonROS2CameraImpl<CameraTraitT>::setBinningY(const size_t& target_binning
 }
 
 template <typename CameraTraitT>
-bool PylonROS2CameraImpl<CameraTraitT>::writeExposure(const float& target_exposure,
-                                                      float& reached_exposure,
-                                                      float& clamped_target)
+bool PylonROS2CameraImpl<CameraTraitT>::setExposure(const float& target_exposure,
+                                                    float& reached_exposure)
 {
     try
     {
         cam_->ExposureAuto.TrySetValue(ExposureAutoEnums::ExposureAuto_Off);
 
-        clamped_target = target_exposure;
-        if ( clamped_target < exposureTime().GetMin() )
+        float exposure_to_set = target_exposure;
+        if ( exposure_to_set < exposureTime().GetMin() )
         {
-            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << clamped_target << ") "
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << exposure_to_set << ") "
                 << "time unreachable! Setting to lower limit: "
                 << exposureTime().GetMin());
-            clamped_target = exposureTime().GetMin();
+            exposure_to_set = exposureTime().GetMin();
         }
-        else if ( clamped_target > exposureTime().GetMax() )
+        else if ( exposure_to_set > exposureTime().GetMax() )
         {
-            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << clamped_target << ") "
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << exposure_to_set << ") "
                 << "time unreachable! Setting to upper limit: "
                 << exposureTime().GetMax());
-            clamped_target = exposureTime().GetMax();
+            exposure_to_set = exposureTime().GetMax();
         }
-        exposureTime().SetValue(clamped_target);
+        exposureTime().SetValue(exposure_to_set);
         reached_exposure = currentExposure();
+
+        if ( std::fabs(reached_exposure - exposure_to_set) > exposureStep() )
+        {
+            // no success if the delta between target and reached exposure
+            // is greater then the exposure step in ms
+            return false;
+        }
     }
     catch ( const GenICam::GenericException &e )
     {
@@ -1118,29 +1124,6 @@ bool PylonROS2CameraImpl<CameraTraitT>::writeExposure(const float& target_exposu
         return false;
     }
     return true;
-}
-
-template <typename CameraTraitT>
-bool PylonROS2CameraImpl<CameraTraitT>::setExposureFast(const float& target_exposure,
-                                                        float& reached_exposure)
-{
-    float clamped_target;
-    return writeExposure(target_exposure, reached_exposure, clamped_target);
-}
-
-template <typename CameraTraitT>
-bool PylonROS2CameraImpl<CameraTraitT>::setExposure(const float& target_exposure,
-                                                    float& reached_exposure)
-{
-    float clamped_target;
-    if ( !writeExposure(target_exposure, reached_exposure, clamped_target) )
-    {
-        return false;
-    }
-
-    // no success if the delta between target and reached exposure
-    // is greater then the exposure step in ms
-    return std::fabs(reached_exposure - clamped_target) <= exposureStep();
 }
 
 template <typename CameraTraitT>
@@ -5062,10 +5045,34 @@ std::string PylonROS2CameraImpl<CameraTraitT>::setMultiCameraChannel(const int& 
 }
 
 template <typename CameraTraitT>
-std::string PylonROS2CameraImpl<CameraTraitT>::setAcquisitionFrameRate(const float& framerate __attribute__((unused)))
+std::string PylonROS2CameraImpl<CameraTraitT>::setAcquisitionFrameRate(const float& framerate)
 {
-    RCLCPP_DEBUG(LOGGER_BASE, "Feature not available except for blaze");
-    return "Feature not available except for blaze";
+    try
+    {
+        // ace 2 and USB expose AcquisitionFrameRate, ace 1 GigE the older AcquisitionFrameRateAbs
+        if ( GenApi::IsAvailable(cam_->AcquisitionFrameRate) )
+        {
+            cam_->AcquisitionFrameRate.SetValue(framerate);
+        }
+        else if ( GenApi::IsAvailable(cam_->AcquisitionFrameRateAbs) )
+        {
+            cam_->AcquisitionFrameRateAbs.SetValue(framerate);
+        }
+        else
+        {
+            RCLCPP_ERROR(LOGGER_BASE, "The connected camera does not support setting the acquisition frame rate");
+            return "The connected camera does not support setting the acquisition frame rate";
+        }
+
+        RCLCPP_DEBUG_STREAM(LOGGER_BASE, "Acquisition frame rate set to " << framerate);
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "An exception while changing the acquisition frame rate occurred: " << e.GetDescription());
+        return e.GetDescription();
+    }
+
+    return "done";
 }
 
 template <typename CameraTraitT>
@@ -5118,10 +5125,26 @@ std::string PylonROS2CameraImpl<CameraTraitT>::enableDistortionCorrection(const 
 }
 
 template <typename CameraTraitT>
-std::string PylonROS2CameraImpl<CameraTraitT>::enableAcquisitionFrameRate(const bool& enable __attribute__((unused)))
+std::string PylonROS2CameraImpl<CameraTraitT>::enableAcquisitionFrameRate(const bool& enable)
 {
-    RCLCPP_DEBUG(LOGGER_BASE, "Feature not available except for blaze");
-    return "Feature not available except for blaze";
+    try
+    {
+        if ( !GenApi::IsAvailable(cam_->AcquisitionFrameRateEnable) )
+        {
+            RCLCPP_ERROR(LOGGER_BASE, "The connected camera does not support enabling the acquisition frame rate");
+            return "The connected camera does not support enabling the acquisition frame rate";
+        }
+
+        cam_->AcquisitionFrameRateEnable.SetValue(enable);
+        RCLCPP_DEBUG_STREAM(LOGGER_BASE, "Acquisition frame rate " << (enable ? "enabled" : "disabled"));
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "An exception while enabling/disabling the acquisition frame rate occurred: " << e.GetDescription());
+        return e.GetDescription();
+    }
+
+    return "done";
 }
 
 template <typename CameraTraitT>

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -1084,37 +1084,31 @@ bool PylonROS2CameraImpl<CameraTraitT>::setBinningY(const size_t& target_binning
 }
 
 template <typename CameraTraitT>
-bool PylonROS2CameraImpl<CameraTraitT>::setExposure(const float& target_exposure,
-                                                    float& reached_exposure)
+bool PylonROS2CameraImpl<CameraTraitT>::writeExposure(const float& target_exposure,
+                                                      float& reached_exposure,
+                                                      float& clamped_target)
 {
     try
     {
         cam_->ExposureAuto.TrySetValue(ExposureAutoEnums::ExposureAuto_Off);
 
-        float exposure_to_set = target_exposure;
-        if ( exposure_to_set < exposureTime().GetMin() )
+        clamped_target = target_exposure;
+        if ( clamped_target < exposureTime().GetMin() )
         {
-            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << exposure_to_set << ") "
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << clamped_target << ") "
                 << "time unreachable! Setting to lower limit: "
                 << exposureTime().GetMin());
-            exposure_to_set = exposureTime().GetMin();
+            clamped_target = exposureTime().GetMin();
         }
-        else if ( exposure_to_set > exposureTime().GetMax() )
+        else if ( clamped_target > exposureTime().GetMax() )
         {
-            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << exposure_to_set << ") "
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired exposure (" << clamped_target << ") "
                 << "time unreachable! Setting to upper limit: "
                 << exposureTime().GetMax());
-            exposure_to_set = exposureTime().GetMax();
+            clamped_target = exposureTime().GetMax();
         }
-        exposureTime().SetValue(exposure_to_set);
+        exposureTime().SetValue(clamped_target);
         reached_exposure = currentExposure();
-
-        if ( std::fabs(reached_exposure - exposure_to_set) > exposureStep() )
-        {
-            // no success if the delta between target and reached exposure
-            // is greater then the exposure step in ms
-            return false;
-        }
     }
     catch ( const GenICam::GenericException &e )
     {
@@ -1124,6 +1118,29 @@ bool PylonROS2CameraImpl<CameraTraitT>::setExposure(const float& target_exposure
         return false;
     }
     return true;
+}
+
+template <typename CameraTraitT>
+bool PylonROS2CameraImpl<CameraTraitT>::setExposureFast(const float& target_exposure,
+                                                        float& reached_exposure)
+{
+    float clamped_target;
+    return writeExposure(target_exposure, reached_exposure, clamped_target);
+}
+
+template <typename CameraTraitT>
+bool PylonROS2CameraImpl<CameraTraitT>::setExposure(const float& target_exposure,
+                                                    float& reached_exposure)
+{
+    float clamped_target;
+    if ( !writeExposure(target_exposure, reached_exposure, clamped_target) )
+    {
+        return false;
+    }
+
+    // no success if the delta between target and reached exposure
+    // is greater then the exposure step in ms
+    return std::fabs(reached_exposure - clamped_target) <= exposureStep();
 }
 
 template <typename CameraTraitT>
@@ -1170,6 +1187,48 @@ bool PylonROS2CameraImpl<CameraTraitT>::setGain(const float& target_gain,
         return false;
     }
     return true;
+}
+
+template <typename CameraTraitT>
+bool PylonROS2CameraImpl<CameraTraitT>::setGainRaw(const float& target_gain,
+                                                   float& reached_gain)
+{
+    try
+    {
+        cam_->GainAuto.TrySetValue(GainAutoEnums::GainAuto_Off);
+
+        float gain_to_set = target_gain;
+        if ( gain_to_set < gain().GetMin() )
+        {
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired raw gain (" << target_gain << ") out of "
+                << "range! Setting to lower limit: " << gain().GetMin());
+            gain_to_set = gain().GetMin();
+        }
+        else if ( gain_to_set > gain().GetMax() )
+        {
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "Desired raw gain (" << target_gain << ") out of "
+                << "range! Setting to upper limit: " << gain().GetMax());
+            gain_to_set = gain().GetMax();
+        }
+
+        // the gain node is a float on ace 2 / USB but an integer on ace 1,
+        // so convert to whatever this camera family actually stores
+        gain().SetValue(static_cast<decltype(gain().GetValue())>(gain_to_set));
+        reached_gain = currentGainRaw();
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "An exception while setting target raw gain to "
+               << target_gain << " occurred: " << e.GetDescription());
+        return false;
+    }
+    return true;
+}
+
+template <typename CameraTraitT>
+float PylonROS2CameraImpl<CameraTraitT>::currentGainRaw()
+{
+    return static_cast<float>(gain().GetValue());
 }
 
 template <typename CameraTraitT>

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige_ace2.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige_ace2.hpp
@@ -69,6 +69,8 @@ public:
     virtual int getDeviceLinkThroughputLimitMode();
     virtual std::string setDeviceLinkThroughputLimit(const int& limit);
     virtual bool setGain(const float& target_gain, float& reached_gain);
+    virtual bool setGainRaw(const float& target_gain, float& reached_gain);
+    virtual float currentGainRaw();
     //virtual std::string setTriggerSource(const int& source);
     virtual std::string setTimerSelector(const int& selector);
     virtual std::string setPTPPriority(const int& value);
@@ -780,6 +782,43 @@ bool PylonROS2GigEAce2Camera::setGain(const float& target_gain, float& reached_g
         return false;
     }
     return true;
+}
+
+bool PylonROS2GigEAce2Camera::setGainRaw(const float& target_gain, float& reached_gain)
+{
+    try
+    {
+        cam_->GainAuto.TrySetValue(GainAutoEnums::GainAuto_Off);
+
+        float gain_to_set = target_gain;
+        if ( gain_to_set < gain().GetMin() )
+        {
+            RCLCPP_WARN_STREAM(LOGGER_GIGE_ACE2, "Desired raw gain (" << target_gain << ") in dB out "
+                << "of range! Setting to lower limit: " << gain().GetMin());
+            gain_to_set = gain().GetMin();
+        }
+        else if ( gain_to_set > gain().GetMax() )
+        {
+            RCLCPP_WARN_STREAM(LOGGER_GIGE_ACE2, "Desired raw gain (" << target_gain << ") in dB out "
+                << "of range! Setting to upper limit: " << gain().GetMax());
+            gain_to_set = gain().GetMax();
+        }
+
+        gain().SetValue(gain_to_set);
+        reached_gain = currentGainRaw();
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_GIGE_ACE2, "An exception while setting target raw gain to "
+               << target_gain << " occurred: " << e.GetDescription());
+        return false;
+    }
+    return true;
+}
+
+float PylonROS2GigEAce2Camera::currentGainRaw()
+{
+    return static_cast<float>(gain().GetValue());
 }
 
 std::string PylonROS2GigEAce2Camera::typeName() const

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -88,9 +88,21 @@ public:
 
     virtual bool setExposure(const float& target_exposure, float& reached_exposure) override;
 
+    virtual bool setExposureFast(const float& target_exposure, float& reached_exposure) override;
+
+    /**
+     * Clamps the target into the camera's range, writes it and reports both the
+     * value the camera settled on and the clamped target it was asked for.
+     */
+    bool writeExposure(const float& target_exposure, float& reached_exposure, float& clamped_target);
+
     virtual bool setAutoflash(const std::map<int, bool> flash_on_lines) override;
 
     virtual bool setGain(const float& target_gain, float& reached_gain) override;
+
+    virtual bool setGainRaw(const float& target_gain, float& reached_gain) override;
+
+    virtual float currentGainRaw() override;
 
     virtual bool setGamma(const float& target_gamma, float& reached_gamma) override;
 

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -88,14 +88,6 @@ public:
 
     virtual bool setExposure(const float& target_exposure, float& reached_exposure) override;
 
-    virtual bool setExposureFast(const float& target_exposure, float& reached_exposure) override;
-
-    /**
-     * Clamps the target into the camera's range, writes it and reports both the
-     * value the camera settled on and the clamped target it was asked for.
-     */
-    bool writeExposure(const float& target_exposure, float& reached_exposure, float& clamped_target);
-
     virtual bool setAutoflash(const std::map<int, bool> flash_on_lines) override;
 
     virtual bool setGain(const float& target_gain, float& reached_gain) override;

--- a/pylon_ros2_camera_component/include/parameter_sequencer.hpp
+++ b/pylon_ros2_camera_component/include/parameter_sequencer.hpp
@@ -1,0 +1,139 @@
+/******************************************************************************
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (C) 2022, Basler AG. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * No contributors' name may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace pylon_ros2_camera
+{
+
+/**
+ * One entry of the gain/exposure cycle. A value is only meant to be written to
+ * the camera when its 'has_' flag is set, so a caller can cycle gain alone,
+ * exposure alone, or both.
+ */
+struct SequenceStep
+{
+    double gain{0.0};
+    double exposure{0.0};
+    bool has_gain{false};
+    bool has_exposure{false};
+};
+
+/**
+ * Walks the cartesian product of a gain list and an exposure list, one entry
+ * per frame, so consecutive frames of the same scene are captured at different
+ * brightness levels. Gain varies fastest, exposure slowest, and a full cycle
+ * visits every pair exactly once.
+ *
+ * Either list may be empty (that parameter is then left alone) or hold a single
+ * entry (that parameter is then constant). Deliberately free of any pylon or
+ * ROS dependency so it can be unit tested on its own.
+ */
+class ParameterSequencer
+{
+public:
+    ParameterSequencer() = default;
+
+    ParameterSequencer(std::vector<double> gains, std::vector<double> exposures)
+        : gains_(std::move(gains))
+        , exposures_(std::move(exposures))
+    {}
+
+    /**
+     * True when neither parameter is cycled and the sequencer has nothing to apply.
+     */
+    bool empty() const
+    {
+        return this->gains_.empty() && this->exposures_.empty();
+    }
+
+    /**
+     * Number of frames in one full cycle.
+     */
+    std::size_t size() const
+    {
+        if (this->empty())
+        {
+            return 0;
+        }
+
+        return this->gainCount() * this->exposureCount();
+    }
+
+    /**
+     * Entry to apply before grabbing frame number 'step'. The step is taken
+     * modulo the cycle length, so a caller can just keep incrementing it.
+     */
+    SequenceStep at(std::size_t step) const
+    {
+        SequenceStep result;
+        if (this->empty())
+        {
+            return result;
+        }
+
+        const std::size_t wrapped = step % this->size();
+
+        if (!this->gains_.empty())
+        {
+            result.gain = this->gains_[wrapped % this->gainCount()];
+            result.has_gain = true;
+        }
+
+        if (!this->exposures_.empty())
+        {
+            // wrapped < gainCount() * exposureCount(), so the division alone is in range
+            result.exposure = this->exposures_[wrapped / this->gainCount()];
+            result.has_exposure = true;
+        }
+
+        return result;
+    }
+
+private:
+    // an absent list still counts as one, so it contributes a single pass
+    // through the other list instead of collapsing the product to zero
+    std::size_t gainCount() const
+    {
+        return this->gains_.empty() ? 1 : this->gains_.size();
+    }
+
+    std::size_t exposureCount() const
+    {
+        return this->exposures_.empty() ? 1 : this->exposures_.size();
+    }
+
+    std::vector<double> gains_;
+    std::vector<double> exposures_;
+};
+
+}  // namespace pylon_ros2_camera

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -211,18 +211,6 @@ public:
                              float& reached_exposure) = 0;
 
     /**
-     * Sets the exposure time without judging the result. Unlike setExposure()
-     * this reports success whenever the camera accepted the write, even if the
-     * camera quantised the value. Meant for per-frame use, where the caller
-     * cannot afford the retry loop that a 'false' triggers.
-     * @param target_exposure the desired exposure time to set in microseconds.
-     * @param reached_exposure time in microseconds
-     * @return false only if a communication error occurred.
-     */
-    virtual bool setExposureFast(const float& target_exposure,
-                                 float& reached_exposure) = 0;
-
-    /**
      * Sets autoflash active for the specified lines
      * @param flash_on_lines map from line e.g., 1 or 2 to a boolean to 
               activate or deactivate the autoflash for this line .

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -211,6 +211,18 @@ public:
                              float& reached_exposure) = 0;
 
     /**
+     * Sets the exposure time without judging the result. Unlike setExposure()
+     * this reports success whenever the camera accepted the write, even if the
+     * camera quantised the value. Meant for per-frame use, where the caller
+     * cannot afford the retry loop that a 'false' triggers.
+     * @param target_exposure the desired exposure time to set in microseconds.
+     * @param reached_exposure time in microseconds
+     * @return false only if a communication error occurred.
+     */
+    virtual bool setExposureFast(const float& target_exposure,
+                                 float& reached_exposure) = 0;
+
+    /**
      * Sets autoflash active for the specified lines
      * @param flash_on_lines map from line e.g., 1 or 2 to a boolean to 
               activate or deactivate the autoflash for this line .
@@ -225,6 +237,21 @@ public:
      * @return false if a communication error occurred or true otherwise.
      */
     virtual bool setGain(const float& target_gain, float& reached_gain) = 0;
+
+    /**
+     * Sets the gain in the camera's own units - dB on ace 2, device specific
+     * units on ace 1 - instead of as a fraction of the gain range. Lets a
+     * configuration carry the values an operator reads off the camera directly.
+     * @param target_gain the target gain in device units.
+     * @param reached_gain the reached gain in device units.
+     * @return false if a communication error occurred or true otherwise.
+     */
+    virtual bool setGainRaw(const float& target_gain, float& reached_gain) = 0;
+
+    /**
+     * @return the currently set gain in the camera's own units.
+     */
+    virtual float currentGainRaw() = 0;
 
     /**
      * Sets the target gamma value

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -71,6 +71,7 @@
 #include "pylon_ros2_camera_interfaces/action/grab_blaze_data.hpp"
 
 // camera
+#include "parameter_sequencer.hpp"
 #include "pylon_ros2_camera.hpp"
 #include "pylon_ros2_camera_parameter.hpp"
 
@@ -208,6 +209,18 @@ protected:
    * @return false if an error occurred.
    */
   virtual bool grabImage();
+
+  /**
+   * @brief Writes one gain/exposure entry of the cycle to the camera.
+   */
+  virtual void applySequenceStep(std::size_t step);
+
+  /**
+   * @brief Applies the gain/exposure entry due for the next frame and advances
+   * the cycle. No-op when no sequence is configured, or when the sequence holds
+   * a single entry - that one is written once at startup instead.
+   */
+  virtual void applyNextSequenceStep();
 
   /**
    * @brief Update the exposure value on the camera
@@ -1831,6 +1844,10 @@ protected:
   // intern
   std::vector<std::size_t> sampling_indices_;
   std::array<float, 256> brightness_exp_lut_{};
+
+  // gain/exposure cycled one entry per frame, empty when the feature is off
+  ParameterSequencer sequencer_;
+  std::size_t sequence_step_{0};
 
   bool is_sleeping_{false};
 

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_parameter.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_parameter.hpp
@@ -327,12 +327,37 @@ public:
     float white_balance_ratio_blue_;
 
     /**
-    * Camera grab strategy 
+    * Camera grab strategy
     * 0 = GrabStrategy_OneByOne
     * 1 = GrabStrategy_LatestImageOnly
     * 2 = GrabStrategy_LatestImages
     */
     int grab_strategy_;
+
+    /**
+     * Gain values cycled one per frame ("manual HDR"). Empty disables cycling.
+     * Interpreted as raw device units when gain_raw_ is set, else as a fraction
+     * of the camera gain range like the 'gain' parameter.
+     */
+    std::vector<double> gain_sequence_;
+
+    /**
+     * Exposure times in microseconds cycled one per frame. Empty disables cycling.
+     */
+    std::vector<double> exposure_sequence_;
+
+    /**
+     * Interpret 'gain' and 'gain_sequence' as raw device units (dB on ace 2,
+     * device specific units on ace 1) instead of a 0..1 fraction of the range.
+     */
+    bool gain_raw_;
+
+    /**
+     * Frame rate written to the camera itself. Negative leaves the camera
+     * untouched. Without this the camera free-runs faster than the node drains
+     * it and the grab queue serves stale frames.
+     */
+    double acquisition_frame_rate_;
 
 
 protected:

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -1203,15 +1203,16 @@ void PylonROS2CameraNode::applySequenceStep(std::size_t step_index)
 
   const SequenceStep step = this->sequencer_.at(step_index);
 
-  // the plain setExposure()/setGain() wrappers retry for up to 5 s when the camera
-  // quantises a value away from the target, which would stall the stream. Per frame we
-  // write once and move on.
+  // reach through to the camera rather than the node wrappers, which retry for up to 5 s
+  // and would stall the stream. A false here usually only means the camera quantised the
+  // value, so it is not worth a per-frame warning.
   if (step.has_exposure)
   {
     float reached_exposure;
-    if (!this->pylon_camera_->setExposureFast(step.exposure, reached_exposure))
+    if (!this->pylon_camera_->setExposure(step.exposure, reached_exposure))
     {
-      RCLCPP_WARN_STREAM(LOGGER, "Failed to set exposure " << step.exposure << " us of the frame sequence");
+      RCLCPP_DEBUG_STREAM(LOGGER, "Exposure " << step.exposure << " us of the frame sequence "
+        << "was not reached exactly, camera settled on " << reached_exposure);
     }
   }
 

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -680,6 +680,18 @@ bool PylonROS2CameraNode::startGrabbing()
     return false;
   }
 
+  this->sequencer_ = ParameterSequencer(this->pylon_camera_parameter_set_.gain_sequence_,
+                                        this->pylon_camera_parameter_set_.exposure_sequence_);
+  this->sequence_step_ = 0;
+  if (!this->sequencer_.empty())
+  {
+    RCLCPP_INFO_STREAM(LOGGER, "Cycling gain/exposure over " << this->sequencer_.size()
+      << " combination(s), one per frame: "
+      << this->pylon_camera_parameter_set_.gain_sequence_.size() << " gain value(s) "
+      << (this->pylon_camera_parameter_set_.gain_raw_ ? "in device units" : "as a fraction of range")
+      << " x " << this->pylon_camera_parameter_set_.exposure_sequence_.size() << " exposure value(s)");
+  }
+
   const std::size_t num_user_outputs = this->pylon_camera_->numUserOutputs();
   this->set_user_output_srvs_.resize(2 * num_user_outputs);
   
@@ -829,12 +841,20 @@ bool PylonROS2CameraNode::startGrabbing()
   }
   
   if (!this->pylon_camera_->isBlaze() && this->pylon_camera_parameter_set_.gain_given_)
-  {   
+  {
     float reached_gain;
-    this->setGain(this->pylon_camera_parameter_set_.gain_, reached_gain);
+    const bool raw = this->pylon_camera_parameter_set_.gain_raw_;
+    if (raw)
+    {
+      this->pylon_camera_->setGainRaw(this->pylon_camera_parameter_set_.gain_, reached_gain);
+    }
+    else
+    {
+      this->setGain(this->pylon_camera_parameter_set_.gain_, reached_gain);
+    }
     RCLCPP_INFO_STREAM(LOGGER, "Attempted to set gain to: "
-            << this->pylon_camera_parameter_set_.gain_ << ", reached: "
-            << reached_gain);
+            << this->pylon_camera_parameter_set_.gain_ << (raw ? " (device units)" : " (fraction of range)")
+            << ", reached: " << reached_gain);
   }
 
   if (!this->pylon_camera_->isBlaze() && pylon_camera_parameter_set_.gamma_given_)
@@ -857,8 +877,11 @@ bool PylonROS2CameraNode::startGrabbing()
             << this->pylon_camera_parameter_set_.brightness_ << ", reached: "
             << reached_brightness);
 
-    if (this->pylon_camera_parameter_set_.brightness_continuous_)
-    {   
+    // continuous auto brightness would keep overwriting the values the cycle writes,
+    // so the two are mutually exclusive
+    const bool sequencing = !this->sequencer_.empty();
+    if (this->pylon_camera_parameter_set_.brightness_continuous_ && !sequencing)
+    {
       if ( this->pylon_camera_parameter_set_.exposure_auto_)
       {
         this->pylon_camera_->enableContinuousAutoExposure();
@@ -869,7 +892,11 @@ bool PylonROS2CameraNode::startGrabbing()
       }
     }
     else
-    { 
+    {
+      if (this->pylon_camera_parameter_set_.brightness_continuous_)
+      {
+        RCLCPP_WARN(LOGGER, "Ignoring brightness_continuous because a gain/exposure sequence is configured");
+      }
       this->pylon_camera_->disableAllRunningAutoBrightessFunctions();
     }
   }
@@ -889,6 +916,24 @@ bool PylonROS2CameraNode::startGrabbing()
   {
     RCLCPP_INFO_STREAM_ONCE(LOGGER, "Startup settings: "
       << "exposure = " << this->pylon_camera_->currentExposure());
+  }
+
+  // Written once here rather than per frame; applyNextSequenceStep() skips constant sequences.
+  if (this->sequencer_.size() == 1)
+  {
+    this->applySequenceStep(0);
+  }
+
+  // Pin the camera's own acquisition rate to keep it from producing faster than this node
+  // drains the grab queue - otherwise the queue backs up and serves frames that were exposed
+  // before the settings written for them, which defeats any per-frame cycling.
+  if (!this->pylon_camera_->isBlaze() && this->pylon_camera_parameter_set_.acquisition_frame_rate_ > 0.0)
+  {
+    const double rate = this->pylon_camera_parameter_set_.acquisition_frame_rate_;
+    const std::string enabled = this->pylon_camera_->enableAcquisitionFrameRate(true);
+    const std::string applied = this->pylon_camera_->setAcquisitionFrameRate(static_cast<float>(rate));
+    RCLCPP_INFO_STREAM(LOGGER, "Attempted to set the camera acquisition frame rate to " << rate
+            << " Hz, enable: " << enabled << ", set: " << applied);
   }
 
   // Framerate Settings
@@ -959,6 +1004,11 @@ void PylonROS2CameraNode::spin()
       const bool any_subscriber = (this->img_raw_pub_.getNumSubscribers() != 0 || this->getNumSubscribersRectImagePub() != 0);
       if (!this->isSleeping() && any_subscriber)
       {
+        // one lock across both halves, so nothing else writing exposure/gain can land
+        // between the settings for this frame and the frame itself
+        std::lock_guard<std::recursive_mutex> lock(this->grab_mutex_);
+        this->applyNextSequenceStep();
+
         if (!this->grabImage())
         {
           continue;
@@ -1138,6 +1188,59 @@ bool PylonROS2CameraNode::grabImage()
   return true;
 }
 
+void PylonROS2CameraNode::applySequenceStep(std::size_t step_index)
+{
+  if (this->sequencer_.empty() || this->pylon_camera_->isBlaze())
+  {
+    return;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(this->grab_mutex_);
+  if (!this->pylon_camera_->isReady())
+  {
+    return;
+  }
+
+  const SequenceStep step = this->sequencer_.at(step_index);
+
+  // the plain setExposure()/setGain() wrappers retry for up to 5 s when the camera
+  // quantises a value away from the target, which would stall the stream. Per frame we
+  // write once and move on.
+  if (step.has_exposure)
+  {
+    float reached_exposure;
+    if (!this->pylon_camera_->setExposureFast(step.exposure, reached_exposure))
+    {
+      RCLCPP_WARN_STREAM(LOGGER, "Failed to set exposure " << step.exposure << " us of the frame sequence");
+    }
+  }
+
+  if (step.has_gain)
+  {
+    float reached_gain;
+    const bool applied = this->pylon_camera_parameter_set_.gain_raw_
+      ? this->pylon_camera_->setGainRaw(step.gain, reached_gain)
+      : this->pylon_camera_->setGain(step.gain, reached_gain);
+    if (!applied)
+    {
+      RCLCPP_WARN_STREAM(LOGGER, "Failed to set gain " << step.gain << " of the frame sequence");
+    }
+  }
+}
+
+void PylonROS2CameraNode::applyNextSequenceStep()
+{
+  // a single-entry sequence never changes, so writing it again every frame would only
+  // cost control-channel round trips ahead of each grab. It is written once at startup.
+  if (this->sequencer_.size() < 2)
+  {
+    return;
+  }
+
+  this->applySequenceStep(this->sequence_step_);
+  this->sequence_step_ = (this->sequence_step_ + 1) % this->sequencer_.size();
+}
+
 bool PylonROS2CameraNode::setExposure(const float& target_exposure, float& reached_exposure)
 {
   std::lock_guard<std::recursive_mutex> lock(this->grab_mutex_);
@@ -1186,6 +1289,16 @@ bool PylonROS2CameraNode::setBrightness(const int& target_brightness,
   {
     RCLCPP_WARN(LOGGER, "Trying to set brightness: there's no brightness parameter with the blaze camera - returning -9999");
     reached_brightness = -9999;
+    return false;
+  }
+
+  // a brightness search drives exposure and gain itself, so it cannot share the camera
+  // with the per-frame cycle. Checked here rather than per caller so the service, the
+  // GrabImages action and the startup path are all covered.
+  if (!this->sequencer_.empty())
+  {
+    RCLCPP_WARN(LOGGER, "Refusing to set brightness while a gain/exposure sequence is configured");
+    reached_brightness = -1;
     return false;
   }
 
@@ -2706,7 +2819,9 @@ void PylonROS2CameraNode::setBrightnessCallback(const std::shared_ptr<SetBrightn
                                           response->reached_brightness,
                                           request->exposure_auto,
                                           request->gain_auto);
-  if (request->brightness_continuous)
+  // setBrightness refuses while a sequence is configured; don't let the auto functions
+  // be switched on behind its back either
+  if (request->brightness_continuous && this->sequencer_.empty())
   {
     if (request->exposure_auto)
     {

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
@@ -29,6 +29,8 @@
 #include "pylon_ros2_camera_parameter.hpp"
 #include <sensor_msgs/image_encodings.hpp>
 
+#include <algorithm>
+
 
 namespace pylon_ros2_camera
 {
@@ -74,6 +76,8 @@ PylonROS2CameraParameter::PylonROS2CameraParameter() :
     white_balance_ratio_green_(1.0),
     white_balance_ratio_blue_(1.0),
     grab_strategy_(0),
+    gain_raw_(false),
+    acquisition_frame_rate_(-1.0),
     camera_frame_("pylon_camera"),
     device_user_id_(""),
     frame_rate_(5.0),
@@ -531,6 +535,46 @@ void PylonROS2CameraParameter::readFromRosParameterServer(rclcpp::Node& nh)
     
     nh.get_parameter("grab_strategy", this->grab_strategy_);
 
+    // gain_sequence
+    RCLCPP_DEBUG(LOGGER, "---> gain_sequence");
+
+    if (!nh.has_parameter("gain_sequence"))
+    {
+        nh.declare_parameter<std::vector<double>>("gain_sequence", std::vector<double>());
+    }
+
+    nh.get_parameter("gain_sequence", this->gain_sequence_);
+
+    // exposure_sequence
+    RCLCPP_DEBUG(LOGGER, "---> exposure_sequence");
+
+    if (!nh.has_parameter("exposure_sequence"))
+    {
+        nh.declare_parameter<std::vector<double>>("exposure_sequence", std::vector<double>());
+    }
+
+    nh.get_parameter("exposure_sequence", this->exposure_sequence_);
+
+    // gain_raw
+    RCLCPP_DEBUG(LOGGER, "---> gain_raw");
+
+    if (!nh.has_parameter("gain_raw"))
+    {
+        nh.declare_parameter<bool>("gain_raw", false);
+    }
+
+    nh.get_parameter("gain_raw", this->gain_raw_);
+
+    // acquisition_frame_rate
+    RCLCPP_DEBUG(LOGGER, "---> acquisition_frame_rate");
+
+    if (!nh.has_parameter("acquisition_frame_rate"))
+    {
+        nh.declare_parameter<double>("acquisition_frame_rate", -1.0);
+    }
+
+    nh.get_parameter("acquisition_frame_rate", this->acquisition_frame_rate_);
+
     // validating parameters
     this->validateParameterSet(nh);
 }
@@ -572,11 +616,55 @@ void PylonROS2CameraParameter::validateParameterSet(rclcpp::Node& nh)
         this->exposure_given_ = false;
     }
 
-    if (this->gain_given_ && ( this->gain_ < 0.0 || this->gain_ > 1.0 ))
+    // in raw mode the gain is in device units (dB on ace 2), so the 0..1 range does not apply
+    if (this->gain_given_ && !this->gain_raw_ && ( this->gain_ < 0.0 || this->gain_ > 1.0 ))
     {
         RCLCPP_WARN_STREAM(LOGGER, "The specified gain value - " << this->gain_ << " % - is out of valid range!"
                                 << "-> Will reset it to default value.");
         this->gain_given_ = false;
+    }
+
+    if (this->gain_given_ && this->gain_raw_ && this->gain_ < 0.0)
+    {
+        RCLCPP_WARN_STREAM(LOGGER, "The specified raw gain value - " << this->gain_ << " - is negative!"
+                                << "-> Will reset it to default value.");
+        this->gain_given_ = false;
+    }
+
+    for (const double gain : this->gain_sequence_)
+    {
+        const bool out_of_range = this->gain_raw_ ? (gain < 0.0) : (gain < 0.0 || gain > 1.0);
+        if (out_of_range)
+        {
+            RCLCPP_WARN_STREAM(LOGGER, "The gain_sequence entry " << gain << " is out of valid range!"
+                                    << " -> Will drop the whole gain sequence.");
+            this->gain_sequence_.clear();
+            break;
+        }
+    }
+
+    for (const double exposure : this->exposure_sequence_)
+    {
+        if (exposure <= 0.0)
+        {
+            RCLCPP_WARN_STREAM(LOGGER, "The exposure_sequence entry " << exposure << " is not positive!"
+                                    << " -> Will drop the whole exposure sequence.");
+            this->exposure_sequence_.clear();
+            break;
+        }
+    }
+
+    // every combination is visited once per cycle, so the cycle grows as the product of both lists.
+    // a label has to stay in view for a whole cycle for the sequence to be of any use.
+    const std::size_t cycle_length = std::max<std::size_t>(this->gain_sequence_.size(), 1)
+                                   * std::max<std::size_t>(this->exposure_sequence_.size(), 1);
+    if (cycle_length > 1 && this->frame_rate_ > 0.0
+        && static_cast<double>(cycle_length) / this->frame_rate_ > 1.0)
+    {
+        RCLCPP_WARN_STREAM(LOGGER, "The gain/exposure cycle needs "
+                                << static_cast<double>(cycle_length) / this->frame_rate_ << " s at "
+                                << this->frame_rate_ << " Hz. Objects passing the camera faster than that "
+                                << "will not be seen at every setting.");
     }
 
     if (this->brightness_given_ && ( this->brightness_ < 0.0 || this->brightness_ > 255 ))

--- a/pylon_ros2_camera_wrapper/config/default.yaml
+++ b/pylon_ros2_camera_wrapper/config/default.yaml
@@ -58,6 +58,29 @@
     #  called 'device specific units'.
     # gain: 0.5
 
+    #  Interpret 'gain' and 'gain_sequence' as raw device units - dB on ace 2,
+    #  device specific units on ace 1 - instead of as a fraction of the gain
+    #  range. Lets a config carry the values read off the camera directly.
+    # gain_raw: false
+
+    #  Gain and exposure values cycled one entry per frame, so consecutive
+    #  frames of the same scene are captured at different brightness levels.
+    #  Useful where a single setting cannot work, e.g. barcode reading, where a
+    #  reflective label needs low gain and a shadowed one needs high gain.
+    #  A full cycle walks the cartesian product of both lists, so N gains and M
+    #  exposures give N*M frames. Either list may be left empty to keep that
+    #  parameter fixed. Not compatible with the auto brightness features, which
+    #  are refused while a sequence is configured.
+    # gain_sequence: [19.0, 12.0, 5.0]
+    # exposure_sequence: [5000.0, 10000.0]
+
+    #  Frame rate written to the camera itself, as opposed to 'frame_rate' which
+    #  only paces this node. Leave negative to keep the camera's own setting.
+    #  Set it when using a sequence: a camera free-running faster than the node
+    #  drains the grab queue serves frames that were exposed before the settings
+    #  meant for them, which defeats the cycling.
+    # acquisition_frame_rate: -1.0
+
     #  Gamma correction of pixel intensity.
     #  Adjusts the brightness of the pixel values output by the camera's sensor
     #  to account for a non-linearity in the human perception of brightness or


### PR DESCRIPTION
### Basic Info

| Info                  | Please fill out this column |
| --------------------- | --------------------------- |
| Platform tested on    | AMR  |
| Related documentation | [coda](https://docs.superhuman.com/d/Autonomous-Mobile-Robot_da82dg_s4hc/New-Basler-driver_suG9Ig17) |
| Ticket                | [AMRNAV-8018](https://lvserv01.logivations.com/browse/AMRNAV-8018) |

Reason for change:

No single gain works for every label — a reflective one needs low gain, one shadowed under a box needs high gain. The legacy pipeline cycled a list of gains outside the driver; this driver had no equivalent.

Separately, `setAcquisitionFrameRate` / `enableAcquisitionFrameRate` were implemented only for the blaze and silently did nothing on an ace 2. Without them the camera outruns the node and serves frames exposed before the settings meant for them.

Changes in this PR:

- New `parameter_sequencer.hpp` — walks the cartesian product of a gain list and an exposure list, one entry per frame, gain varying fastest. No pylon or ROS dependency.
- Four new parameters, all defaulting to off: `gain_sequence`, `exposure_sequence`, `gain_raw`, `acquisition_frame_rate`.
- `setGainRaw()` / `currentGainRaw()` — gain in the camera's own units (dB on ace 2) instead of a fraction of `[Gain.Min, Gain.Max]`. Needs an ace 2 override because that class shadows `gain()` with a different return type, same as `setGain` already does.
- `setAcquisitionFrameRate` / `enableAcquisitionFrameRate` implemented for non-blaze cameras: `AcquisitionFrameRate` with an `AcquisitionFrameRateAbs` fallback, gated on `IsAvailable`. Blaze override untouched.
- Cycling applied in `spin()` before each grab and under the same lock as the grab. A single-entry sequence is written once at startup instead of every frame.
- Auto brightness refused while a sequence is configured — the check sits in `setBrightness()`, so it covers the service, the `GrabImages` action and startup.

10 files, +564/−16. Nothing changes for a config that does not set the new parameters.

Result:

amr47, `[19, 12, 5]` dB × `[3000, 2000]` µs. Period 6 held over hundreds of frames with no drift, set-to-frame lag exactly one frame and deterministic.

| Setting | Predicted | Measured | Sat |
| --- | --- | --- | --- |
| 5 dB @ 2000 µs | 48 | 48.34 | 0% |
| 5 dB @ 3000 µs | 72 | 72.83 | 0% |
| 12 dB @ 2000 µs | 108 | 107.68 | 0% |
| 12 dB @ 3000 µs | 162 | 162.03 | 0% |
| 19 dB @ 2000 µs | 241 | 233.16 | 42% |
| 19 dB @ 3000 µs | 362 | 254.13 | 95% |

Unclipped levels match prediction within 1%. A 7 dB step should give 2.239×; measured 2.225 / 2.243 / 2.223. Acquisition frame rate now reports `done` instead of `Feature not available except for blaze`, with zero buffer failures over 7311 frames.
